### PR TITLE
Improve IME inset adjustment for edge-to-edge

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallback.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallback.java
@@ -80,6 +80,62 @@ class ImeSyncDeferringInsetsCallback {
     this.insetsListener = new InsetsListener();
   }
 
+  private int getNavigationBarInsetsToExclude(@NonNull WindowInsets windowInsets) {
+    if (view == null) {
+      return 0;
+    }
+    int systemUiFlags = view.getWindowSystemUiVisibility();
+    boolean shouldExcludeNavigationBarInsets =
+        (systemUiFlags & View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION) == 0
+            && (systemUiFlags & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
+
+    View rootView = view.getRootView();
+    if (rootView != null) {
+      if (rootView.getFitsSystemWindows()) {
+        shouldExcludeNavigationBarInsets = true;
+      } else {
+        boolean rootReservesNavigationBarSpace = rootView.getPaddingBottom() > 0;
+        if (!rootReservesNavigationBarSpace) {
+          int rootHeight = rootView.getHeight();
+          int viewHeight = view.getHeight();
+          if (rootHeight > 0 && viewHeight > 0 && rootHeight > viewHeight) {
+            rootReservesNavigationBarSpace = true;
+          }
+        }
+        if (!rootReservesNavigationBarSpace) {
+          shouldExcludeNavigationBarInsets = false;
+        } else {
+          shouldExcludeNavigationBarInsets = true;
+        }
+      }
+    }
+
+    if (shouldExcludeNavigationBarInsets) {
+      return windowInsets.getInsets(WindowInsets.Type.navigationBars()).bottom;
+    }
+    return 0;
+  }
+
+  private WindowInsets adjustImeInsets(@NonNull WindowInsets windowInsets) {
+    int excludedInsets = getNavigationBarInsetsToExclude(windowInsets);
+    if (excludedInsets == 0) {
+      return windowInsets;
+    }
+    Insets imeInsets = windowInsets.getInsets(deferredInsetTypes);
+    if (imeInsets.bottom <= 0) {
+      return windowInsets;
+    }
+    int newImeBottom = Math.max(imeInsets.bottom - excludedInsets, 0);
+    if (newImeBottom == imeInsets.bottom) {
+      return windowInsets;
+    }
+    WindowInsets.Builder builder = new WindowInsets.Builder(windowInsets);
+    builder.setInsets(
+        deferredInsetTypes,
+        Insets.of(imeInsets.left, imeInsets.top, imeInsets.right, newImeBottom));
+    return builder.build();
+  }
+
   // Add this object's event listeners to its view.
   void install() {
     view.setWindowInsetsAnimationCallback(animationCallback);
@@ -148,19 +204,22 @@ class ImeSyncDeferringInsetsCallback {
 
       // The IME insets include the height of the navigation bar. If the app isn't laid out behind
       // the navigation bar, this causes the IME insets to be too large during the animation.
-      // To fix this, we subtract the navigationBars bottom inset if the system UI flags for laying
-      // out behind the navigation bar aren't present.
-      int excludedInsets = 0;
-      int systemUiFlags = view.getWindowSystemUiVisibility();
-      if ((systemUiFlags & View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION) == 0
-          && (systemUiFlags & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0) {
-        excludedInsets = insets.getInsets(WindowInsets.Type.navigationBars()).bottom;
-      }
+      // To fix this, we subtract the navigationBars bottom inset when the view hierarchy is not
+      // laid out behind it. Historically this was detected via the deprecated system UI flags, but
+      // on newer Android versions these flags may remain unset even when the content extends behind
+      // the navigation bar (e.g. Android 15's default edge-to-edge mode). Therefore, we additionally
+      // check whether the root view is reserving space for the navigation bar via padding or a
+      // reduced child height.
+      int excludedInsets = getNavigationBarInsetsToExclude(insets);
 
       WindowInsets.Builder builder = new WindowInsets.Builder(lastWindowInsets);
+      Insets imeInsets = insets.getInsets(deferredInsetTypes);
       Insets newImeInsets =
           Insets.of(
-              0, 0, 0, Math.max(insets.getInsets(deferredInsetTypes).bottom - excludedInsets, 0));
+              imeInsets.left,
+              imeInsets.top,
+              imeInsets.right,
+              Math.max(imeInsets.bottom - excludedInsets, 0));
       builder.setInsets(deferredInsetTypes, newImeInsets);
 
       // Directly call onApplyWindowInsets of the view as we do not want to pass through
@@ -203,7 +262,7 @@ class ImeSyncDeferringInsetsCallback {
         // is not part of the animation and instead, represents the final state
         // of the inset after the animation is completed. Thus, we defer the processing
         // of this WindowInset until the animation completes.
-        lastWindowInsets = windowInsets;
+        lastWindowInsets = adjustImeInsets(windowInsets);
         needsSave = false;
       }
       if (animating) {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -11,6 +11,7 @@ import static org.mockito.AdditionalMatchers.gt;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.isNotNull;
 import static org.mockito.Mockito.isNull;
@@ -2628,6 +2629,10 @@ public class TextInputPluginTest {
             FlutterView testView = spy(new FlutterView(activity));
             when(testView.getWindowSystemUiVisibility())
                 .thenReturn(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+            View rootView = mock(View.class);
+            doReturn(rootView).when(testView).getRootView();
+            when(rootView.getPaddingBottom()).thenReturn(40);
+            when(rootView.getFitsSystemWindows()).thenReturn(true);
 
             TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
             ScribeChannel scribeChannel = new ScribeChannel(mock(DartExecutor.class));
@@ -2667,8 +2672,8 @@ public class TextInputPluginTest {
             // the
             // animation instead of being applied immediately
             imeSyncCallback.getAnimationCallback().onPrepare(animation);
-            builder.setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, 100));
-            builder.setInsets(WindowInsets.Type.navigationBars(), Insets.of(0, 0, 0, 0));
+            builder.setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, 140));
+            builder.setInsets(WindowInsets.Type.navigationBars(), Insets.of(0, 0, 0, 40));
             imeSyncCallback.getInsetsListener().onApplyWindowInsets(testView, builder.build());
 
             verify(flutterRenderer, atLeast(1)).setViewportMetrics(viewportMetricsCaptor.capture());
@@ -2685,19 +2690,19 @@ public class TextInputPluginTest {
 
             // Progress the animation and ensure that the navigation bar insets have been subtracted
             // from the IME insets
-            builder.setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, 25));
+            builder.setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, 80));
             builder.setInsets(WindowInsets.Type.navigationBars(), Insets.of(0, 0, 0, 40));
             imeSyncCallback.getAnimationCallback().onProgress(builder.build(), animationList);
 
             verify(flutterRenderer, atLeast(1)).setViewportMetrics(viewportMetricsCaptor.capture());
-            assertEquals(0, viewportMetricsCaptor.getValue().viewInsetBottom);
+            assertEquals(40, viewportMetricsCaptor.getValue().viewInsetBottom);
 
-            builder.setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, 50));
+            builder.setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, 140));
             builder.setInsets(WindowInsets.Type.navigationBars(), Insets.of(0, 0, 0, 40));
             imeSyncCallback.getAnimationCallback().onProgress(builder.build(), animationList);
 
             verify(flutterRenderer, atLeast(1)).setViewportMetrics(viewportMetricsCaptor.capture());
-            assertEquals(10, viewportMetricsCaptor.getValue().viewInsetBottom);
+            assertEquals(100, viewportMetricsCaptor.getValue().viewInsetBottom);
 
             // End the animation and ensure that the bottom insets match the lastWindowInsets that
             // we set
@@ -2725,6 +2730,12 @@ public class TextInputPluginTest {
                 .thenReturn(
                     View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
                         | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
+            View rootView = mock(View.class);
+            doReturn(rootView).when(testView).getRootView();
+            when(rootView.getPaddingBottom()).thenReturn(0);
+            when(rootView.getHeight()).thenReturn(1000);
+            doReturn(1000).when(testView).getHeight();
+            when(rootView.getFitsSystemWindows()).thenReturn(false);
 
             TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
             ScribeChannel scribeChannel = new ScribeChannel(mock(DartExecutor.class));
@@ -2820,6 +2831,10 @@ public class TextInputPluginTest {
             FlutterView testView = spy(new FlutterView(activity));
             when(testView.getWindowSystemUiVisibility())
                 .thenReturn(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+            View rootView = mock(View.class);
+            doReturn(rootView).when(testView).getRootView();
+            when(rootView.getPaddingBottom()).thenReturn(40);
+            when(rootView.getFitsSystemWindows()).thenReturn(true);
 
             TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
             ScribeChannel scribeChannel = new ScribeChannel(mock(DartExecutor.class));


### PR DESCRIPTION
## Summary
- add helper methods in `ImeSyncDeferringInsetsCallback` to reuse navigation-bar exclusion logic and to adjust stored IME insets so the final dispatch matches the animated values
- extend the Robolectric tests to stub `fitsSystemWindows` and to cover IME progress values that now reach the final inset, preventing keyboard jumps in edge-to-edge layouts

## Testing
- attempted to run `./flutter/bin/et build --config android_debug_unopt_x64 //flutter/shell/platform/android:android_jar` *(terminated after several minutes at ~2% progress due to resource limits)*
- attempted to run `python3 flutter/testing/run_tests.py --type=java --android-variant android_debug_unopt_x64` *(fails: SSL handshake when downloading Gradle dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf097f0c4832bba008f849239b21a